### PR TITLE
Route Edge Impulse arena allocations to PSRAM

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include "driver/rtc_io.h"
 #include "driver/i2c.h"
 #include "driver/periph_ctrl.h"
+#include "esp_heap_caps.h"
 #include <SPI.h>
 #include <Wire.h>
 #include <U8g2lib.h>
@@ -50,11 +51,22 @@
 __attribute__((weak)) void *ei_malloc(size_t size) {
     // For large allocations (>1KB), prefer PSRAM
     if (size > 1024) {
-        void* ptr = heap_caps_malloc(size, MALLOC_CAP_SPIRAM);
+        void* ptr = heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
         if (ptr) return ptr;
     }
     // Fallback to regular heap
     return heap_caps_malloc(size, MALLOC_CAP_8BIT);
+}
+
+__attribute__((weak)) void *ei_calloc(size_t nitems, size_t size) {
+    size_t total = nitems * size;
+    if (total > 1024) {
+        void *ptr = heap_caps_calloc(nitems, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+        if (ptr) {
+            return ptr;
+        }
+    }
+    return heap_caps_calloc(nitems, size, MALLOC_CAP_8BIT);
 }
 
 __attribute__((weak)) void ei_free(void* ptr) {


### PR DESCRIPTION
## Summary
- include the ESP heap capabilities header so the PSRAM allocation helpers are available to the sketch
- extend the Edge Impulse port overrides to route ei_calloc through PSRAM in the same way as ei_malloc so large tensor arenas no longer exhaust internal RAM

## Testing
- `pio run` *(fails: PlatformIO CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc62b7c618832d909961894c67fbc4